### PR TITLE
Better ansible grokking

### DIFF
--- a/bastion.yml
+++ b/bastion.yml
@@ -114,9 +114,12 @@
         - name: ansible_runner
           prospectors:
             - input_type: log
-              document_type: ansible_runner
+              document_type: ansible-runner
               paths:
-                - "/var/www/html/cron-logs/*/current.log"
-                - "/var/www/html/cron-logs/*/latest.log"
+                - "/var/www/html/cron-logs/*/*current.log"
+              multiline:
+                pattern: '^$'
+                negate: true
+                match: before
 
     - role: fail2ban  # This should be last

--- a/roles/logstash/files/etc/logstash/conf.d/16-ansible-runner.conf
+++ b/roles/logstash/files/etc/logstash/conf.d/16-ansible-runner.conf
@@ -1,10 +1,13 @@
 filter {
   if [type] == "ansible-runner" {
       grok {
-        match => { "message" => "%{SUPERAWESOMEANSIBLELOG}"}
-      }
-      date {
-        match => [ "timestamp", "dd/MMM/yyyy:HH:mm:ssZ" ]
+        add_field => { "received_at" => "%{@timestamp}" }
+        match => { "message" => [
+            "(?m)PLAYBOOK: %{NOTSPACE:playbook} \*+%{GREEDYDATA:playbook_details}",
+            "(?m)PLAY RECAP \*+%{GREEDYDATA:play_recap}",
+            "(?m)PLAY \[%{DATA:play}\] \*+%{GREEDYDATA:play_details}",
+            "(?m)TASK \[%{DATA:task}\] \*+%{GREEDYDATA:task_details}"
+        ]}
       }
   }
 }


### PR DESCRIPTION
Make the filebeat document-type match the logstash filter type.

Remove the date filter since we don't have timestamps to parse,
which means we have to rely on logstash received time for event
timestamps.

Create multiline events split by empty lines in the log file.

Add multiple grok patterns for the various types of output we get
from ansible-playbook.

Signed-off-by: K Jonathan Harker <Jonathan.Harker@ibm.com>